### PR TITLE
Allow specifying AR command

### DIFF
--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -334,8 +334,11 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
         elif target == 'cross-win64':
             # MinGW in 16.04 is lacking std::mutex for unknown reason
             cc_bin = 'x86_64-w64-mingw32-g++'
-            flags += ['--cpu=x86_64', '--cc-abi-flags=-static',
-                      '--ar-command=x86_64-w64-mingw32-ar', '--without-os-feature=threads']
+            flags += ['--cpu=x86_64', '--cc-abi-flags=-static', '--without-os-feature=threads']
+            if os.getenv('AR') is None:
+                flags += [ '--ar-command=x86_64-w64-mingw32-ar' ]
+            else:
+                flags += [ '--ar-command=%s' % os.getenv('AR') ]
             test_cmd = [os.path.join(root_dir, 'botan-test.exe')] + test_cmd[1:]
             test_prefix = ['wine']
         else:


### PR DESCRIPTION
Closes #4806

If we allow the ar command to be overridden for the cross-win64 target instead of being hard-coded, it will be possible to use MXE to do the compilation.

I chose the AR environment variable because that matches [what Gnu Make uses](https://www.gnu.org/software/make/manual/make.html#index-CFLAGS).

If AR is not set, the script falls back to the hard-coded value, making this change backward compatible.